### PR TITLE
34.1 Kanban part 6

### DIFF
--- a/src/main/java/ru/kanban/model/Epic.java
+++ b/src/main/java/ru/kanban/model/Epic.java
@@ -60,7 +60,7 @@ public class Epic extends Task {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         Epic epic = (Epic) o;
-        return Objects.equals(subtasks, epic.subtasks);
+        return (getId() == epic.getId()) && Objects.equals(subtasks, epic.subtasks);
     }
 
     @Override
@@ -74,7 +74,8 @@ public class Epic extends Task {
         return "Epic {" + " ID: " + getId() + ", Name: '" + getName() + "', Description: '" + getDescription() + "'" +
                 " Status: '" + getStatus() + "' }" +
                 ln +
-                "Subtasks: " + subtasks +
+                "Subtasks: " + subtasks.stream().map(Task::getId) +
                 '}';
     }
+
 }

--- a/src/main/java/ru/kanban/model/Epic.java
+++ b/src/main/java/ru/kanban/model/Epic.java
@@ -1,5 +1,5 @@
 package ru.kanban.model;
-
+//
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/ru/kanban/model/Subtask.java
+++ b/src/main/java/ru/kanban/model/Subtask.java
@@ -31,12 +31,12 @@ public class Subtask extends Task {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         Subtask subtask = (Subtask) o;
-        return Objects.equals(epic.getId(), subtask.epic.getId());
+        return (getId() == subtask.getId()) && getEpic().getId() == subtask.getEpic().getId();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), epic.getId());
+        return Objects.hash(super.hashCode(), getEpic().getId());
     }
 
     @Override
@@ -46,6 +46,7 @@ public class Subtask extends Task {
                 "    Name: '" + getName() + "'" + ln +
                 "    Description: '" + getDescription() + "'" + ln +
                 "    Status: '" + getStatus() + "'" + ln +
-                "    Subtask of Epic: '" + epic + "'" + ln;
+                "    Subtask of Epic: '" + epic.getId() + "'" + ln;
     }
+
 }

--- a/src/main/java/ru/kanban/model/Subtask.java
+++ b/src/main/java/ru/kanban/model/Subtask.java
@@ -1,5 +1,5 @@
 package ru.kanban.model;
-
+//
 import java.util.Objects;
 
 public class Subtask extends Task {

--- a/src/main/java/ru/kanban/model/Task.java
+++ b/src/main/java/ru/kanban/model/Task.java
@@ -1,5 +1,5 @@
 package ru.kanban.model;
-
+//
 import java.util.Objects;
 
 public class Task {

--- a/src/main/java/ru/kanban/model/Task.java
+++ b/src/main/java/ru/kanban/model/Task.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 public class Task {
     private String name;
     private String description;
-    private int id = 1;
+    private int id;
     private Status status;
     private boolean isViewed;
     private TaskType type;
@@ -69,12 +69,12 @@ public class Task {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Task task = (Task) o;
-        return id == task.id && Objects.equals(name, task.name) && status == task.status;
+        return id == task.id;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, id, status);
+        return Objects.hash(id);
     }
 
     @Override

--- a/src/main/java/ru/kanban/service/FileBackedHistoryManager.java
+++ b/src/main/java/ru/kanban/service/FileBackedHistoryManager.java
@@ -1,5 +1,5 @@
 package ru.kanban.service;
-
+//
 import java.io.*;
 import ru.kanban.model.Subtask;
 import ru.kanban.model.Task;

--- a/src/main/java/ru/kanban/service/FileBackedTaskManager.java
+++ b/src/main/java/ru/kanban/service/FileBackedTaskManager.java
@@ -1,5 +1,5 @@
 package ru.kanban.service;
-
+//
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/src/main/java/ru/kanban/service/InMemoryTaskManager.java
+++ b/src/main/java/ru/kanban/service/InMemoryTaskManager.java
@@ -1,5 +1,5 @@
 package ru.kanban.service;
-
+//
 import java.util.*;
 import ru.kanban.exceptions.TaskNotFoundException;
 import ru.kanban.model.Epic;

--- a/src/main/java/ru/kanban/service/InMemoryTaskManager.java
+++ b/src/main/java/ru/kanban/service/InMemoryTaskManager.java
@@ -116,6 +116,7 @@ public class InMemoryTaskManager implements TaskManager {
         if (!epics.containsKey(epic.getId())) {
             throw new TaskNotFoundException("Epic with id: " + epic.getId() + " not found");
         }
+
         epic.updateStatus();
         epics.put(epic.getId(), epic);
         return Optional.of(epic);

--- a/src/test/java/ru/kanban/model/EpicTest.java
+++ b/src/test/java/ru/kanban/model/EpicTest.java
@@ -80,6 +80,7 @@ class EpicTest {
 
     @Test
     void whenEpicsHasDifferentFieldsThenFalse() {
+        secondEpic.setId(2);
         assertThat(firstEpic.equals(secondEpic)).isFalse();
     }
 

--- a/src/test/java/ru/kanban/model/SubtaskTest.java
+++ b/src/test/java/ru/kanban/model/SubtaskTest.java
@@ -29,12 +29,14 @@ class SubtaskTest {
         Subtask anotherSubtask = new Subtask(
                 "First subtask", "Subtask of First Epic", Status.NEW, secondEpic
         );
+        anotherSubtask.setId(2);
         assertThat(firstSubtask).isNotEqualTo(anotherSubtask);
     }
 
     @Test
     void whenSubtaskHasSameEpicsButDifferentFieldsThenNotEquals() {
         Subtask anotherSubtask = new Subtask("Second", "Test", Status.NEW, firstEpic);
+        anotherSubtask.setId(2);
         assertThat(firstSubtask).isNotEqualTo(anotherSubtask);
     }
 

--- a/src/test/java/ru/kanban/model/TaskTest.java
+++ b/src/test/java/ru/kanban/model/TaskTest.java
@@ -24,6 +24,7 @@ class TaskTest {
 
 @Test
     void whenTasksHasDifferentFieldsThenFalse() {
+        secondTask.setId(2);
     assertThat(firstTask).isNotEqualTo(secondTask);
 }
 

--- a/src/test/java/ru/kanban/service/FileBackedHistoryManagerTest.java
+++ b/src/test/java/ru/kanban/service/FileBackedHistoryManagerTest.java
@@ -1,6 +1,7 @@
 package ru.kanban.service;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
@@ -38,6 +39,7 @@ class FileBackedHistoryManagerTest {
     @Test
     void whenAddTaskToHistoryThenFileContainsTask() throws IOException {
         File history = historyManager.getHistoryFile();
+        task1.setId(1);
         epic1.setId(2);
         subtask1.setId(3);
         historyManager.addToHistory(task1);
@@ -60,7 +62,7 @@ class FileBackedHistoryManagerTest {
     }
 
     @Test
-    void whenLoadFromFileThenHistoryExpected() {
+    void whenLoadFromFileThenHistoryExpected() throws FileNotFoundException {
         fileBackedTaskManager.addTask(task1);
         fileBackedTaskManager.addEpic(epic1);
         fileBackedTaskManager.addSubtask(subtask1);

--- a/src/test/java/ru/kanban/service/FileBackedHistoryManagerTest.java
+++ b/src/test/java/ru/kanban/service/FileBackedHistoryManagerTest.java
@@ -1,5 +1,5 @@
 package ru.kanban.service;
-
+//
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/test/java/ru/kanban/service/FileBackedTaskManagerTest.java
+++ b/src/test/java/ru/kanban/service/FileBackedTaskManagerTest.java
@@ -1,5 +1,5 @@
 package ru.kanban.service;
-
+//
 import java.io.*;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/ru/kanban/service/FileBackedTaskManagerTest.java
+++ b/src/test/java/ru/kanban/service/FileBackedTaskManagerTest.java
@@ -1,8 +1,6 @@
 package ru.kanban.service;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,6 +69,7 @@ class FileBackedTaskManagerTest {
     void testFromStringToEpic() {
         String string = "1,EPIC,Epic 1,NEW,Description 1,";
         Epic expected = new Epic("Epic 1", "Description 1", NEW);
+        expected.setId(1);
         Epic res = (Epic) fileBackedTaskManager.fromString(string);
         assertThat(res).isEqualTo(expected);
     }
@@ -79,6 +78,7 @@ class FileBackedTaskManagerTest {
     void testFromStringToSubtask() {
         String string = "1,SUBTASK,Subtask 1,NEW,Description 1,2";
         Subtask expected = new Subtask("Subtask 1", "Description 1", NEW, epic1);
+        expected.setId(1);
         Subtask res = (Subtask) fileBackedTaskManager.fromString(string);
         assertThat(res).isEqualTo(expected);
     }
@@ -123,7 +123,7 @@ class FileBackedTaskManagerTest {
     }
 
     @Test
-    void whenThenLoadFromFileThenManagerHasSameContent() {
+    void whenThenLoadFromFileThenManagerHasSameContent() throws FileNotFoundException {
         String[] args = {tempFile.toString(), tempHistoryFile.toString()};
         List<Task> tasksBeforeLoad = fileBackedTaskManager.getTasks();
         List<Epic> epicsBeforeLoad = fileBackedTaskManager.getEpics();
@@ -135,5 +135,273 @@ class FileBackedTaskManagerTest {
         assertThat(tasksAfterLoad).containsAll(tasksBeforeLoad);
         assertThat(epicsAfterLoad).containsAll(epicsBeforeLoad);
         assertThat(subtasksAfterLoad).containsAll(subtasksBeforeLoad);
+    }
+
+    @Test
+    void whenNotEnoughArgumentsThenExceptionThrown() {
+        String[] args = {tempFile.toString()};
+        assertThatThrownBy(() ->
+                FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Not enough arguments, for execute. Enter paths: to TaskManager and History");
+
+    }
+
+    @Test
+    void whenHistoryFileIsNotCsvThenExceptionThrownWithExpectedMessage() {
+        String[] args = {tempFile.toString(), ""};
+        assertThatThrownBy(() ->
+                FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Illegal file extension. Expected : .csv");
+    }
+
+    @Test
+    void whenTaskFileIsNotCsvThenExceptionThrownWithExpectedMessage() {
+        String[] args = {"", tempHistoryFile.toString()};
+        assertThatThrownBy(() ->
+                FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Illegal file extension. Expected : .csv");
+    }
+
+    @Test
+    void whenTaskFileNotExistsThenExceptionThrownWithExpectedMessage() {
+        String[] args = {"./example_root.csv", tempHistoryFile.toString()};
+        assertThatThrownBy(() ->
+                FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining(
+                        "File with tasks not found");
+    }
+
+    @Test
+    void whenHistoryFileNotExistsThenExceptionThrownWithExpectedMessage() {
+        String[] args = {tempFile.toString(), "./example_root.csv"};
+        assertThatThrownBy(() ->
+                FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining(
+                        "File with history not found");
+    }
+
+    @Test
+    void whenTaskFileCsvStructureIsWrongThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                    id,type,name,status,description,epic id
+                    asd,
+                    """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Must be: id,type,name,status,description,epic id");
+    }
+
+    @Test
+    void whenTaskFileContainsWrongIdThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                    id,type,name,status,description,epic id
+                    asd,TASK,Task,NEW,description,
+                    """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Task ID is missing.");
+    }
+
+    @Test
+    void whenTaskFileContainsIllegalTypeThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                    id,type,name,status,description,epic id
+                    1,Type,Task,NEW,description,
+                    """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Illegal task type.");
+    }
+
+    @Test
+    void whenTaskFileContainsIllegalNameThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                    id,type,name,status,description,epic id
+                    1,TASK, ,NEW,description,
+                    """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Task name is missing");
+    }
+
+    @Test
+    void whenTaskFileContainsIllegalStatusThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                    id,type,name,status,description,epic id
+                    1,TASK,Task,STATUS,description,
+                    """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Illegal status provided");
+    }
+
+    @Test
+    void whenDescriptionIsMissingInTaskFileThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                     id,type,name,status,description,epic id
+                     1,TASK,Task,NEW, ,
+                     """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Description is missing");
+    }
+
+    @Test
+    void whenSubtaskIsMissingEpicIdAtTaskFileThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempFile = File.createTempFile("test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempFile))
+        )) {
+            writer.println("""
+                     id,type,name,status,description,epic id
+                     1,SUBTASK,Subtask,NEW,desc, ,
+                     """);
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Epic ID at subtask: Subtask is invalid");
+    }
+
+    @Test
+    void whenHistoryCsvContainsAnotherContentThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("HelloWorld");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Must be: id,type,name,status,description,epic ");
+    }
+
+    @Test
+    void whenHistoryContainsIllegalIDThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("asd,Type,Name,NEW,Desc");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Task ID is missing.");
+    }
+
+    @Test
+    void whenHistoryContainsIllegalTypeThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("1,Type,Name,New,Desc");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Illegal task type.");
+    }
+
+    @Test
+    void whenHistoryContainsIllegalNameThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("1,TASK, ,NEW,Desc");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Task name is missing");
+    }
+
+    @Test
+    void whenHistoryContainsIllegalDescThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("1,TASK,Task,NEW, ,");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Description is missing");
+    }
+
+    @Test
+    void whenHistoryContainsSubtaskWithEmptyEpicIDThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("1,SUBTASK,Subtask,NEW,Desc, ");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Epic ID at subtask: Subtask is invalid");
+    }
+
+    @Test
+    void whenHistoryContainsSubtaskWithoutEpicThenExceptionThrownWithCorrectMessage() throws IOException {
+        tempHistoryFile = File.createTempFile("history_test", ".csv");
+        try (PrintWriter writer = new PrintWriter(
+                new OutputStreamWriter(new FileOutputStream(tempHistoryFile))
+        )) {
+            writer.println("1,SUBTASK,Subtask,NEW,Desc,");
+        }
+        String[] args = {tempFile.toString(), tempHistoryFile.toString()};
+        assertThatThrownBy(() -> FileBackedTaskManager.loadFromFile(args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Epic ID at subtask: Subtask is missing");
     }
 }

--- a/src/test/java/ru/kanban/service/InMemoryTaskManagerTest.java
+++ b/src/test/java/ru/kanban/service/InMemoryTaskManagerTest.java
@@ -1,5 +1,5 @@
 package ru.kanban.service;
-
+//
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/ru/kanban/service/InMemoryTaskManagerTest.java
+++ b/src/test/java/ru/kanban/service/InMemoryTaskManagerTest.java
@@ -44,6 +44,7 @@ class InMemoryTaskManagerTest {
     void whenGetTaskThenReturnsExpectedTask() {
         taskManager.addTask(firstTask);
         Task expected = new Task("First Task", "First Task", Status.NEW);
+        expected.setId(1);
         assertThat(taskManager.getTask(1).get()).isEqualTo(expected);
     }
 
@@ -87,7 +88,9 @@ class InMemoryTaskManagerTest {
         taskManager.addTask(secondTask);
         secondTask.setId(firstTask.getId());
         taskManager.updateTask(secondTask);
-        assertFalse(taskManager.getTasks().contains(firstTask));
+        String expectedName = secondTask.getName();
+        String result = taskManager.getTask(1).get().getName();
+        assertThat(result).isEqualTo(expectedName);
     }
 
     @Test
@@ -168,11 +171,12 @@ class InMemoryTaskManagerTest {
 
     @Test
     void whenUpdateEpicWithSameStatusesThenStatusStillSame() {
+        Epic updatedEpic = new Epic("updated", "desc", Status.NEW);
+        updatedEpic.setId(1);
         taskManager.addEpic(firstEpic);
         taskManager.addEpic(secondEpic);
-        secondEpic.setId(firstEpic.getId());
-        taskManager.updateEpic(secondEpic);
-        assertThat(taskManager.getEpics()).doesNotContain(firstEpic);
+        taskManager.updateEpic(updatedEpic);
+        assertThat(taskManager.getEpics().toString()).doesNotContain(firstEpic.getName());
         Status expectedStatus = Status.NEW;
         Status result = taskManager.getEpic(1).get().getStatus();
         assertThat(result).isEqualTo(expectedStatus);
@@ -227,6 +231,7 @@ class InMemoryTaskManagerTest {
         firstEpic.setStatus(Status.DONE);
         taskManager.addSubtask(firstSubtask);
         assertThat(firstEpic.getStatus()).isEqualTo(Status.NEW);
+        secondEpic.setId(1);
         taskManager.addSubtask(secondSubtask);
         firstSubtask.setStatus(Status.DONE);
         taskManager.updateSubtask(firstSubtask);
@@ -245,6 +250,7 @@ class InMemoryTaskManagerTest {
     void whenGetSubtasksThenExpectedResult() {
         taskManager.addEpic(firstEpic);
         taskManager.addSubtask(firstSubtask);
+        taskManager.addEpic(secondEpic);
         taskManager.addSubtask(secondSubtask);
         List<Subtask> expected = List.of(firstSubtask, secondSubtask);
         List<Subtask> result = taskManager.getSubtasks();
@@ -255,6 +261,7 @@ class InMemoryTaskManagerTest {
     void whenDeleteSubtaskThenManagerDoesntContainSubtask() {
         taskManager.addEpic(firstEpic);
         taskManager.addSubtask(firstSubtask);
+        taskManager.addEpic(secondEpic);
         taskManager.addSubtask(secondSubtask);
         taskManager.deleteSubtask(firstSubtask.getId());
         List<Subtask> result = taskManager.getSubtasks();
@@ -274,6 +281,7 @@ class InMemoryTaskManagerTest {
     void whenDeleteSubtaskWithInvalidIdThenThrowsException() {
         taskManager.addEpic(firstEpic);
         taskManager.addSubtask(firstSubtask);
+        taskManager.addEpic(secondEpic);
         taskManager.addSubtask(secondSubtask);
         TaskNotFoundException exception = assertThrows(
                 TaskNotFoundException.class, () -> taskManager.deleteSubtask(1)
@@ -285,6 +293,7 @@ class InMemoryTaskManagerTest {
     void whenDeleteAllSubtasksIsSuccessful() {
         taskManager.addEpic(firstEpic);
         taskManager.addSubtask(firstSubtask);
+        taskManager.addEpic(secondEpic);
         taskManager.addSubtask(secondSubtask);
         taskManager.deleteAllSubtasks();
         List<Subtask> result = taskManager.getSubtasks();
@@ -295,6 +304,7 @@ class InMemoryTaskManagerTest {
     void whenDeleteAllSubtasksThenEpicHasNoSubtasks() {
         taskManager.addEpic(firstEpic);
         taskManager.addSubtask(firstSubtask);
+        taskManager.addEpic(secondEpic);
         taskManager.addSubtask(secondSubtask);
         taskManager.deleteAllSubtasks();
         assertThat(firstEpic.getSubtasks()).isEmpty();


### PR DESCRIPTION
Исправления:
-При некорректной записи в файл выбрасывается собственное исключение
-Исправлено сравнение обьектов по equals & hashcode
-Задачи более не присваивают ID по умолчанию при создании обьекта
-Добавлены тесты на валидацию структуры csv файла
-Адаптированы тесты под все вышеперечисленные исправления